### PR TITLE
最新の仕様に対応

### DIFF
--- a/slack_log_gas.gs
+++ b/slack_log_gas.gs
@@ -1,5 +1,5 @@
-const FOLDER_NAME = "slack_backup";
-const SpreadSheetName = "slack_backup";
+const FOLDER_NAME = "Folder Name which is logs are saved";
+const SpreadSheetName = "SpreadSheet Name which is logs are saved";
 
 const FOLDER_ID = PropertiesService.getScriptProperties().getProperty('folder_id');
 if (!FOLDER_ID) {

--- a/slack_log_gas.gs
+++ b/slack_log_gas.gs
@@ -1,5 +1,5 @@
-const FOLDER_NAME = "Folder Name which is logs are saved";
-const SpreadSheetName = "SpreadSheet Name which is logs are saved";
+const FOLDER_NAME = "slack_backup";
+const SpreadSheetName = "slack_backup";
 
 const FOLDER_ID = PropertiesService.getScriptProperties().getProperty('folder_id');
 if (!FOLDER_ID) {
@@ -82,7 +82,7 @@ var SlackAccessor = (function () {
   p.requestAPI = function (path, params) {
     if (params === void 0) { params = {}; }
     var url = "https://slack.com/api/" + path + "?";
-    var qparams = [("token=" + encodeURIComponent(this.APIToken))];
+    var qparams = [];
     for (var k in params) {
       qparams.push(encodeURIComponent(k) + "=" + encodeURIComponent(params[k]));
     }
@@ -90,7 +90,12 @@ var SlackAccessor = (function () {
 
     console.log("==> GET " + url);
 
-    var response = UrlFetchApp.fetch(url);
+    let options = {
+		"headers": {
+            "Authorization" : "Bearer " + encodeURIComponent(this.APIToken)
+        }
+    }
+    var response = UrlFetchApp.fetch(url, options);
     var data = JSON.parse(response.getContentText());
     if (data.error) {
       console.log(data);
@@ -305,7 +310,7 @@ var SpreadsheetController = (function () {
       for (let i = first_row; i <= lastRow; i++) {
         if (!(sheet.getRange(i, COL_REPLY_COUNT).isBlank())) {
           ts = sheet.getRange(i, COL_TIME).getValue();
-          ts_array.push(ts.toFixed(6).toString());
+          ts_array.push(ts);
         }
       }
 
@@ -388,6 +393,9 @@ var SpreadsheetController = (function () {
     if (record.length > 0) {
       var range = sheet.insertRowsAfter(lastRow || 1, record.length)
         .getRange(lastRow + 1, 1, record.length, COL_MAX);
+      // tsを入れる列は少数が切り捨てられないよう文字列形式に設定
+      sheet.getRange(1,COL_TIME,sheet.getMaxRows(),1).setNumberFormat('@');
+      // レコードをセット
       range.setValues(record);
     }
 

--- a/slack_log_gas.gs
+++ b/slack_log_gas.gs
@@ -91,7 +91,7 @@ var SlackAccessor = (function () {
     console.log("==> GET " + url);
 
     let options = {
-		"headers": {
+        "headers": {
             "Authorization" : "Bearer " + encodeURIComponent(this.APIToken)
         }
     }


### PR DESCRIPTION
本日実行したところ、最近の仕様変更により動作しなくなっていたため下記2点の対応を行いました。

・Slackがクエリパラメータによるトークンの指定を受け付けなくなっているため、Authorizationヘッダにトークンを指定するように変更
・タイムスタンプが小数点の前後合わせて16桁あり、スプレッドシートに張り付けた際桁落ちが発生してスレッドの取得ができなくなっていたため、文字列として保存するように変更


